### PR TITLE
Fixed the BUG(OSError: [Errno 25] Inappropriate ioctl for device) tha…

### DIFF
--- a/Ingram/utils/logo.py
+++ b/Ingram/utils/logo.py
@@ -326,7 +326,11 @@ def generate_logo() -> list:
         font = random.choice(ingram_fonts).split('\n')
         font_width = max([len(i) for i in font])
         font_height = len(font)
-        if font_width + icon_width + 2 < os.get_terminal_size()[0]:
+        try:
+            if font_width + icon_width + 2 < os.get_terminal_size()[0]:
+                found = True
+                break
+        except:
             found = True
             break
     if not found:


### PR DESCRIPTION
…t has been occurred when use this script on background via nohup.
`nohup python3 run_ingram.py -i targets.txt -o 218 -t 1248 &`
```
Traceback (most recent call last):
  File "/home/projects/Ingram/run_ingram.py", line 10, in <module>
    from Ingram.utils import config
  File "/home/projects/Ingram/Ingram/utils/__init__.py", line 4, in <module>
    from Ingram.utils.logo import logo
  File "/home/projects/Ingram/Ingram/utils/logo.py", line 351, in <module>
    logo = generate_logo()
  File "/home/projects/Ingram/Ingram/utils/logo.py", line 329, in generate_logo
    if font_width + icon_width + 2 < os.get_terminal_size()[0]:
OSError: [Errno 25] Inappropriate ioctl for device
```