### PR TITLE
Fix gevent LoopExit crash and add --no-resume option

### DIFF
--- a/Ingram/data.py
+++ b/Ingram/data.py
@@ -36,6 +36,8 @@ class Data:
 
     def _load_state_from_disk(self):
         """加载上次运行状态"""
+        if self.config.no_resume:
+            return
         # done & found & run time
         state_file = os.path.join(self.config.out_dir, f".{self.taskid}")
         if os.path.exists(state_file):
@@ -187,7 +189,10 @@ class SnapshotPipeline:
 
     def process(self, core):
         while not core.finish():
-            exploit_func, results = self.get()
+            try:
+                exploit_func, results = self.pipeline.get(timeout=5)
+            except Exception:
+                continue
             self.workers.submit(self._snapshot, exploit_func, results)
             with self.task_count_lock:
                 self.task_count += 1

--- a/Ingram/utils/argparse.py
+++ b/Ingram/utils/argparse.py
@@ -11,6 +11,7 @@ def get_parse():
     parser.add_argument('-T', '--timeout', type=int, default=3, help='requests timeout')
     parser.add_argument('-D', '--disable_snapshot', action='store_true', help='disable snapshot')
     parser.add_argument('--debug', action='store_true', help='log all msg')
+    parser.add_argument('--no-resume', action='store_true', help='do not resume from previous scan, start fresh')
 
     args = parser.parse_args()
     return args


### PR DESCRIPTION
## Motivation and Context

- **Issue #118**: `SnapshotPipeline.process()` crashes with `gevent.exceptions.LoopExit` when the gevent hub has no pending events, because `self.pipeline.get()` blocks forever
- **Issue #135**: No way to start a fresh scan without resuming from a previous interrupted scan

## Changes

1. **Fix LoopExit crash**: Added `timeout=5` to `self.pipeline.get()` in `SnapshotPipeline.process()` and wrapped it in a try/except. When the queue is empty and times out, the loop simply continues to check `core.finish()` instead of crashing.

2. **Add `--no-resume` flag**: New CLI argument that skips loading the previous scan state from disk, allowing users to start a fresh scan. Usage: `python run_ingram.py -i in.txt -o out --no-resume`

## How Has This Been Tested

- Verified Python syntax is correct for both modified files
- The timeout-based approach is a standard pattern for avoiding gevent LoopExit in long-running queue consumers

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

Closes #118, Closes #135